### PR TITLE
update deploy.sh to support versioned patch files

### DIFF
--- a/9.9.0.patch
+++ b/9.9.0.patch
@@ -1,0 +1,13 @@
+diff --git a/Jobs.php b/Jobs.php
+index 043d923..9f1342d 100644
+--- a/Jobs.php
++++ b/Jobs.php
+@@ -402,7 +402,7 @@ class Jobs
+ 			## EMAILS TO SEND
+ 			// Initialize email
+ 			$email = new Message();
+-			$email->setFrom($project_contact_email);
++			$email->setFrom('please-do-not-reply@ufl.edu');
+ 			$email->setFromName($GLOBALS['project_contact_name']);
+ 			$email->setSubject("[REDCap] {$lang['cron_08']}");
+ 			$emailContents = "{$lang['cron_02']}<br><br>{$lang['cron_12']}<br><br>

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,5 +18,21 @@ export REDCAP_VERSION=$2
 # determine the directory where this script resides
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+PATCH_VERSIONS=$(mktemp)
+$(ls *.patch | grep -v "sql" | sed "s/\.patch//;" > $PATCH_VERSIONS)
+if [[ $(cat $PATCH_VERSIONS | grep "$REDCAP_VERSION") ]]; then
+    REDCAP_PATCH_VERSION=$REDCAP_VERSION
+else
+    echo "${REDCAP_VERSION}" >> "$PATCH_VERSIONS"
+    if [[ "$(cat $PATCH_VERSIONS | sort -V | head -n 1)" == "$REDCAP_VERSION" ]]; then
+        # provided version is earlier than any updated version, use base patch.patch file
+        REDCAP_PATCH_VERSION="patch"
+    else
+        # use closest lower version patch file
+        REDCAP_PATCH_VERSION=$(cat $PATCH_VERSIONS | sort -V | grep "$REDCAP_VERSION" -B 1 | head -n1)
+    fi
+fi
+rm $PATCH_VERSIONS
+
 cd $REDCAP_ROOT/redcap_v$REDCAP_VERSION/Classes/
-patch -p1 < $DIR/patch.patch
+patch -p1 --dry-run < $DIR/${REDCAP_PATCH_VERSION}.patch

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,4 +35,4 @@ fi
 rm $PATCH_VERSIONS
 
 cd $REDCAP_ROOT/redcap_v$REDCAP_VERSION/Classes/
-patch -p1 --dry-run < $DIR/${REDCAP_PATCH_VERSION}.patch
+patch -p1 < $DIR/${REDCAP_PATCH_VERSION}.patch


### PR DESCRIPTION
Addresses #2 

Updates deploy.sh to support versioned patches in the format `N.M.O.patch` any version prior to the earliest `N.M.O.patch` will use `patch.patch`. In the event there are multiple versions, the closest version lower than or equal to the version provided will be used.