### PR TITLE
Add v11.2.4.patch, updated location

### DIFF
--- a/11.2.4.patch
+++ b/11.2.4.patch
@@ -7,7 +7,7 @@ index 5ad592c..6a24e90 100644
  			// Initialize email
  			$email = new Message();
 -			$email->setFrom($project_contact_email);
-+			$email->setFrom('ctsit-redcap-reply@ufl.edu');
++			$email->setFrom('ctsit-redcap-reply@ad.ufl.edu');
  			$email->setFromName($GLOBALS['project_contact_name']);
  			$email->setSubject("[REDCap] {$lang['cron_08']}");
  			$emailContents = "{$lang['cron_02']}<br><br>{$lang['cron_12']}<br><br>

--- a/11.2.4.patch
+++ b/11.2.4.patch
@@ -1,0 +1,13 @@
+diff --git a/Jobs.php b/Jobs.php
+index 5ad592c..6a24e90 100644
+--- a/Jobs.php
++++ b/Jobs.php
+@@ -485,7 +485,7 @@ class Jobs
+ 			## EMAILS TO SEND
+ 			// Initialize email
+ 			$email = new Message();
+-			$email->setFrom($project_contact_email);
++			$email->setFrom('ctsit-redcap-reply@ufl.edu');
+ 			$email->setFromName($GLOBALS['project_contact_name']);
+ 			$email->setSubject("[REDCap] {$lang['cron_08']}");
+ 			$emailContents = "{$lang['cron_02']}<br><br>{$lang['cron_12']}<br><br>


### PR DESCRIPTION
Please double check the address I set, I used your latest change to `patch.patch`, but it's different from `9.9.0.patch`

Not sure why this didn't get fixed by fuzzing. The offset isn't that large and a different patch succeeded with an offset of 136! This same patch didn't play nice until I stopped stripping the carriage return, possibly related.

`redcap_deployment` can be tested with different patches with a bit of abuse in the target ini: `patch_repos = [ "--branch add_version_11.2.4 --single-branch git@github.com:chemikyle/change_from_address_in_dashboard_reminder.git" ]`